### PR TITLE
Allow running with docker instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ examples of the main language features.
 You will need to install [Livebook](https://github.com/livebook-dev/livebook) then open the notebook that you're interested in 
 (see below).
 
+Alternatively, if you have [docker](https://docs.docker.com/get-docker/) installed, then you can just run `./docker-run.sh` instead and that will start the Livebook for you.
+
 ## Introductory material
 
 Topics covered in the [introductory livebook](/notebook.livemd) include:

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z  "$(which docker1)" ]; then
+if [ -z  "$(which docker)" ]; then
     echo "You need Docker installed to run this script."
     echo "Installation instructions can be found at: https://docs.docker.com/get-docker/"
     echo

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z  "$(which docker1)" ]; then
+    echo "You need Docker installed to run this script."
+    echo "Installation instructions can be found at: https://docs.docker.com/get-docker/"
+    echo
+    echo "Alternatively you can check out the README for other ways to run the Livebook."
+    exit 1
+fi
+
+# In order to access and save notebooks directly from this
+#  repo we mount the local directory into the container.
+# We specify the user with "-u $(id -u):$(id -g)"
+#  so that the created files have proper permissions
+docker run -p 8080:8080 -p 8081:8081 --pull always -u $(id -u):$(id -g) -v $(pwd):/data livebook/livebook


### PR DESCRIPTION
This PR adds a script that makes running the Livebook as simple as running a script - no install required.
Assuming you have docker installed that is.